### PR TITLE
fix: made icon show up on tab for all pages

### DIFF
--- a/AugDocumentScanner/view/about.html
+++ b/AugDocumentScanner/view/about.html
@@ -6,6 +6,14 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <title>About</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+<link rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="./images/docScan.png" />
+<link rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="./images/docScan.png" />
 <style>
 section {
   display: -webkit-flex;

--- a/AugDocumentScanner/view/help.html
+++ b/AugDocumentScanner/view/help.html
@@ -9,7 +9,14 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <title>Help</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-
+    <link rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href="./images/docScan.png" />
+    <link rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href="./images/docScan.png" />
 
 <style>
   /* custom styles here */

--- a/AugDocumentScanner/view/pdfgen.html
+++ b/AugDocumentScanner/view/pdfgen.html
@@ -8,7 +8,14 @@
     <!--CSS links-->
     <link rel="stylesheet" href="styles.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-
+    <link rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href="./images/docScan.png" />
+    <link rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href="./images/docScan.png" />
     <!--scripts-->
     <script src="https://unpkg.com/pdf-lib@1.4.0"></script>
     <script src="https://unpkg.com/downloadjs@1.4.7"></script>


### PR DESCRIPTION
This commit made sure the icon on the tab was displayed for all tabs and not just the homepage.

* fix: displays tab icon for all pages

addresses #50