### PR TITLE
Feature/Change: Generate PDF opens to a new tab

### DIFF
--- a/AugDocumentScanner/controller/controller.js
+++ b/AugDocumentScanner/controller/controller.js
@@ -227,6 +227,10 @@ async function generatePDF(images, pageSize) {
 async function downloadPDF(pdfDoc) {
   //PDFDocument to bytes (a Uint8Array)
   const pdfBytes = await pdfDoc.save()
+  //pdfBytes is placed into a blob which can create a URL to be opened into a new tab
+  let blb = new Blob([pdfBytes], {type: 'application/pdf'});
+  let link = window.URL.createObjectURL(blb);
+  window.open(link);
   // Trigger the browser to download the PDF document
-  download(pdfBytes, "docScan.pdf", "application/pdf");
+  //download(pdfBytes, "docScan.pdf", "application/pdf");
 }


### PR DESCRIPTION
The Generate PDF button will now open the new pdf to a different tab to be previewed and downloaded. This replaces the button just downloading the PDF. This was done to keep the functionality of being able to download the newly generated PDF but now the user can preview the PDF in a new tab on the browser. So now they can look at the PDF, download it, and even print it from the browser.

addresses #36